### PR TITLE
Implement itinerary version APIs (6.1, 6.2) with JSONB support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    runtimeOnly 'org.postgresql:postgresql:42.7.7'
+    implementation 'org.postgresql:postgresql:42.7.7'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }

--- a/src/main/java/com/laioffer/tripplanner/config/JdbcConvertersConfig.java
+++ b/src/main/java/com/laioffer/tripplanner/config/JdbcConvertersConfig.java
@@ -1,0 +1,19 @@
+package com.laioffer.tripplanner.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
+
+import java.util.List;
+
+@Configuration
+public class JdbcConvertersConfig {
+
+    @Bean
+    public JdbcCustomConversions jdbcCustomConversions() {
+        return new JdbcCustomConversions(List.of(
+                new PgObjectToStringConverter(),
+                new StringToPgObjectConverter()
+        ));
+    }
+}

--- a/src/main/java/com/laioffer/tripplanner/config/PgObjectToStringConverter.java
+++ b/src/main/java/com/laioffer/tripplanner/config/PgObjectToStringConverter.java
@@ -1,0 +1,13 @@
+package com.laioffer.tripplanner.config;
+
+import org.postgresql.util.PGobject;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+
+@ReadingConverter
+public class PgObjectToStringConverter implements Converter<PGobject, String> {
+    @Override
+    public String convert(PGobject source) {
+        return source == null ? null : source.getValue();
+    }
+}

--- a/src/main/java/com/laioffer/tripplanner/config/StringToPgObjectConverter.java
+++ b/src/main/java/com/laioffer/tripplanner/config/StringToPgObjectConverter.java
@@ -1,0 +1,22 @@
+package com.laioffer.tripplanner.config;
+
+import org.postgresql.util.PGobject;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+
+@WritingConverter
+public class StringToPgObjectConverter implements Converter<String, PGobject> {
+    @Override
+    public PGobject convert(String source) {
+        if (source == null) return null;
+
+        PGobject pg = new PGobject();
+        try {
+            pg.setType("jsonb");
+            pg.setValue(source);
+            return pg;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid jsonb value", e);
+        }
+    }
+}

--- a/src/main/java/com/laioffer/tripplanner/controller/ItineraryVersionController.java
+++ b/src/main/java/com/laioffer/tripplanner/controller/ItineraryVersionController.java
@@ -1,0 +1,40 @@
+package com.laioffer.tripplanner.controller;
+
+import com.laioffer.tripplanner.model.ItineraryContentResponse;
+import com.laioffer.tripplanner.model.UpdateItineraryContentRequest;
+import com.laioffer.tripplanner.model.UpdateItineraryContentResponse;
+import com.laioffer.tripplanner.service.ItineraryVersionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/itineraries")
+public class ItineraryVersionController {
+
+    private final ItineraryVersionService itineraryVersionService;
+
+    public ItineraryVersionController(ItineraryVersionService itineraryVersionService) {
+        this.itineraryVersionService = itineraryVersionService;
+    }
+
+    @GetMapping("/{id}/content")
+    public ItineraryContentResponse getCurrentContent(@PathVariable Long id) {
+        return new ItineraryContentResponse(
+                true,
+                itineraryVersionService.getCurrentContent(id),
+                null
+        );
+    }
+
+    @PutMapping("/{id}/content")
+    public ResponseEntity<?> updateContent(
+            @PathVariable("id") long itineraryId,
+            @RequestBody UpdateItineraryContentRequest request
+    ) {
+        long newVersionId = itineraryVersionService.updateItineraryContent(itineraryId, request);
+        return ResponseEntity.ok(new UpdateItineraryContentResponse(true, newVersionId, null));
+    }
+}
+

--- a/src/main/java/com/laioffer/tripplanner/model/ItineraryContentDTO.java
+++ b/src/main/java/com/laioffer/tripplanner/model/ItineraryContentDTO.java
@@ -1,0 +1,3 @@
+package com.laioffer.tripplanner.model;
+
+public record ItineraryContentDTO(Long versionId, Integer versionNo, Object data) {}

--- a/src/main/java/com/laioffer/tripplanner/model/ItineraryContentResponse.java
+++ b/src/main/java/com/laioffer/tripplanner/model/ItineraryContentResponse.java
@@ -1,0 +1,7 @@
+package com.laioffer.tripplanner.model;
+
+public record ItineraryContentResponse(
+        boolean success,
+        ItineraryContentDTO data,
+        String error
+) {}

--- a/src/main/java/com/laioffer/tripplanner/model/UpdateItineraryContentRequest.java
+++ b/src/main/java/com/laioffer/tripplanner/model/UpdateItineraryContentRequest.java
@@ -1,0 +1,25 @@
+package com.laioffer.tripplanner.model;
+
+import java.util.List;
+
+public class UpdateItineraryContentRequest {
+    private List<PoiPlacement> pois;
+
+    public List<PoiPlacement> getPois() { return pois; }
+    public void setPois(List<PoiPlacement> pois) { this.pois = pois; }
+
+    public static class PoiPlacement {
+        private Long poiId;
+        private Integer day;
+        private Integer order;
+
+        public Long getPoiId() { return poiId; }
+        public void setPoiId(Long poiId) { this.poiId = poiId; }
+
+        public Integer getDay() { return day; }
+        public void setDay(Integer day) { this.day = day; }
+
+        public Integer getOrder() { return order; }
+        public void setOrder(Integer order) { this.order = order; }
+    }
+}

--- a/src/main/java/com/laioffer/tripplanner/model/UpdateItineraryContentResponse.java
+++ b/src/main/java/com/laioffer/tripplanner/model/UpdateItineraryContentResponse.java
@@ -1,0 +1,28 @@
+package com.laioffer.tripplanner.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class UpdateItineraryContentResponse {
+
+    private boolean success;
+    private Data data;
+    private String error;
+
+    public UpdateItineraryContentResponse(boolean success, Long newVersionId, String error) {
+        this.success = success;
+        this.data = success ? new Data(newVersionId) : null;
+        this.error = error;
+    }
+
+    public boolean isSuccess() { return success; }
+    public Data getData() { return data; }
+    public String getError() { return error; }
+
+    public static class Data {
+        @JsonProperty("newVersionId")
+        private Long newVersionId;
+
+        public Data(Long newVersionId) { this.newVersionId = newVersionId; }
+        public Long getNewVersionId() { return newVersionId; }
+    }
+}

--- a/src/main/java/com/laioffer/tripplanner/repository/ItineraryVersionRepository.java
+++ b/src/main/java/com/laioffer/tripplanner/repository/ItineraryVersionRepository.java
@@ -1,8 +1,10 @@
 package com.laioffer.tripplanner.repository;
 
 import com.laioffer.tripplanner.entity.ItineraryVersionEntity;
+import org.springframework.data.jdbc.repository.query.Modifying;
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,5 +21,23 @@ public interface ItineraryVersionRepository extends ListCrudRepository<Itinerary
     
     @Query("SELECT MAX(version_no) FROM itinerary_versions WHERE itinerary_id = :itineraryId")
     Integer findMaxVersionNoByItineraryId(Long itineraryId);
+
+    @Modifying
+    @Query("""
+    INSERT INTO itinerary_versions
+      (created_at, data, is_published, itinerary_id, name, updated_at, version_no)
+    VALUES
+      (:createdAt, CAST(:data AS jsonb), :isPublished, :itineraryId, :name, :updatedAt, :versionNo)
+    """)
+    void insertVersion(
+            @Param("createdAt") java.time.Instant createdAt,
+            @Param("data") String data,
+            @Param("isPublished") Boolean isPublished,
+            @Param("itineraryId") Long itineraryId,
+            @Param("name") String name,
+            @Param("updatedAt") java.time.Instant updatedAt,
+            @Param("versionNo") Integer versionNo
+    );
 }
+
 

--- a/src/main/java/com/laioffer/tripplanner/service/ItineraryVersionService.java
+++ b/src/main/java/com/laioffer/tripplanner/service/ItineraryVersionService.java
@@ -1,0 +1,163 @@
+package com.laioffer.tripplanner.service;
+
+import com.laioffer.tripplanner.entity.ItineraryVersionEntity;
+import com.laioffer.tripplanner.model.ItineraryContentDTO;
+import com.laioffer.tripplanner.model.UpdateItineraryContentRequest;
+import com.laioffer.tripplanner.repository.ItineraryVersionRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class ItineraryVersionService {
+
+    private final ItineraryVersionRepository versionRepo;
+    private final ObjectMapper objectMapper;
+
+    public ItineraryVersionService(ItineraryVersionRepository versionRepo,
+                                   ObjectMapper objectMapper) {
+        this.versionRepo = versionRepo;
+        this.objectMapper = objectMapper;
+    }
+
+    public ItineraryContentDTO getCurrentContent(Long itineraryId) {
+        ItineraryVersionEntity v = versionRepo.findLatestByItineraryId(itineraryId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Version not found"));
+
+        Object parsed;
+        try {
+            parsed = objectMapper.readValue(v.data(), Object.class);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Invalid JSON data");
+        }
+
+        return new ItineraryContentDTO(v.id(), v.versionNo(), parsed);
+    }
+
+    @Transactional
+    public Long updateItineraryContent(
+            Long itineraryId,
+            UpdateItineraryContentRequest request
+    ) {
+
+        // 0. check
+        if (request == null || request.getPois() == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST, "pois is required");
+        }
+
+        // 1. read the latest version
+        ItineraryVersionEntity current = versionRepo
+                .findLatestByItineraryId(itineraryId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Version not found"));
+
+        // 2. read jason
+        Map<String, Object> oldRoot;
+        try {
+            oldRoot = objectMapper.readValue(
+                    current.data(),
+                    new TypeReference<Map<String, Object>>() {}
+            );
+        } catch (Exception e) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Invalid JSON data");
+        }
+
+        // 3. keep original routes
+        Object routesObj = oldRoot.get("routes");
+        Map<String, Object> routes =
+                (routesObj instanceof Map<?, ?> m)
+                        ? (Map<String, Object>) m
+                        : new LinkedHashMap<>();
+
+        // 4. group by day and rank by order
+        Map<Integer, List<UpdateItineraryContentRequest.PoiPlacement>> byDay =
+                request.getPois().stream()
+                        .filter(p ->
+                                p.getPoiId() != null &&
+                                        p.getDay() != null &&
+                                        p.getOrder() != null
+                        )
+                        .collect(Collectors.groupingBy(
+                                UpdateItineraryContentRequest.PoiPlacement::getDay,
+                                TreeMap::new,
+                                Collectors.toList()
+                        ));
+
+        // 5. days list
+        List<Map<String, Object>> days = new ArrayList<>();
+
+        for (Map.Entry<Integer,
+                List<UpdateItineraryContentRequest.PoiPlacement>> entry
+                : byDay.entrySet()) {
+
+            Integer day = entry.getKey();
+            List<UpdateItineraryContentRequest.PoiPlacement> pois = entry.getValue();
+
+            pois.sort(Comparator.comparing(
+                    UpdateItineraryContentRequest.PoiPlacement::getOrder));
+
+            List<Map<String, Object>> poiList = new ArrayList<>();
+            for (UpdateItineraryContentRequest.PoiPlacement p : pois) {
+                Map<String, Object> poi = new LinkedHashMap<>();
+                poi.put("poiId", p.getPoiId());
+                poi.put("order", p.getOrder());
+                poiList.add(poi);
+            }
+
+            Map<String, Object> dayObj = new LinkedHashMap<>();
+            dayObj.put("day", day);
+            dayObj.put("pois", poiList);
+
+            days.add(dayObj);
+        }
+
+        // 6. new data Json
+        Map<String, Object> newData = new LinkedHashMap<>();
+        newData.put("days", days);
+        newData.put("routes", routes);
+
+        String newJson;
+        try {
+            newJson = objectMapper.writeValueAsString(newData);
+        } catch (Exception e) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Failed to serialize JSON");
+        }
+
+        // 7. new version_no
+        Integer maxNo = versionRepo.findMaxVersionNoByItineraryId(itineraryId);
+        int newVersionNo = (maxNo == null ? 1 : maxNo + 1);
+
+        // 8. save new version
+        Instant now = Instant.now();
+        versionRepo.insertVersion(
+                now,              // created_at
+                newJson,          // data (String → SQL CAST into jsonb)
+                false,            // is_published
+                itineraryId,      // itinerary_id
+                current.name(),   // name
+                now,              // updated_at
+                newVersionNo      // version_no
+        );
+
+        // 9. return newVersionId
+        Long newVersionId = versionRepo
+                .findByItineraryIdAndVersionNo(itineraryId, newVersionNo)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.INTERNAL_SERVER_ERROR, "Failed to fetch new version id"))
+                .id();
+
+        return newVersionId;
+    }
+}
+
+


### PR DESCRIPTION
1.Create new files for API 6.1 & 6.2

- Add ItineraryVersionService, ItineraryVersionController, and DTOs for itinerary version/content.

- Add config package to register JDBC converters for Postgres jsonb (PGobject ↔ String).

2.Update existing files

- Update ItineraryVersionRepository to handle jsonb write/read type issues (e.g., custom insert / casting).

- build.gradle: change Postgres dependency from runtimeOnly to implementation so PGobject is available at compile time.

3.Test with postman
GET http://localhost:8080/itineraries/1/content
<img width="830" height="702" alt="image" src="https://github.com/user-attachments/assets/ef408750-b19e-475f-b1ed-78089c075184" />

PUT  http://localhost:8080/itineraries/1/content
<img width="830" height="702" alt="image" src="https://github.com/user-attachments/assets/906d9a7a-7bf1-4a6b-90e6-293033ed4c6c" />
